### PR TITLE
added libgmp-dev to apt-line

### DIFF
--- a/ubuntu/18.04/vivado-petalinux/2020.1/Dockerfile
+++ b/ubuntu/18.04/vivado-petalinux/2020.1/Dockerfile
@@ -17,7 +17,7 @@ RUN dpkg --add-architecture i386 && \
                                                       tofrodos iproute2 gawk net-tools libncurses5-dev tftp tftpd-hpa zlib1g-dev \
                                                       libssl-dev flex bison libselinux1 diffstat xvfb chrpath xterm libtool socat \
                                                       autoconf texinfo gcc-multilib libsdl1.2-dev libglib2.0-dev zlib1g:i386 wget \
-                                                      libtool-bin locales cpio python3 libgtk2.0-0 rlwrap rsync && \
+                                                      libtool-bin locales cpio python3 libgtk2.0-0 libgmp-dev rlwrap rsync && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
vivado_hls project requires work-around for gmp.h under libgmp-dev installed environment (see https://forums.xilinx.com/t5/High-Level-Synthesis-HLS/Vivado-2015-3-HLS-Bug-gmp-h/td-p/661141), on the otherhand work-arounded codes emits error on libgmp-dev-less environment.

This fix makes vivado docker image include libgmp-dev, matching environment with popular ubuntu server and always enable gmp.h work-around.