### PR TITLE
added faketime libs to vivado-petalinux 2020.1

### DIFF
--- a/ubuntu/18.04/vivado-petalinux/2020.1/Dockerfile
+++ b/ubuntu/18.04/vivado-petalinux/2020.1/Dockerfile
@@ -17,7 +17,7 @@ RUN dpkg --add-architecture i386 && \
                                                       tofrodos iproute2 gawk net-tools libncurses5-dev tftp tftpd-hpa zlib1g-dev \
                                                       libssl-dev flex bison libselinux1 diffstat xvfb chrpath xterm libtool socat \
                                                       autoconf texinfo gcc-multilib libsdl1.2-dev libglib2.0-dev zlib1g:i386 wget \
-                                                      libtool-bin locales cpio python3 libgtk2.0-0 libgmp-dev rlwrap rsync && \
+                                                      libtool-bin locales cpio python3 libgtk2.0-0 libgmp-dev faketime rlwrap rsync && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
vivado and vivado_hls have errors when system clock is set to year 2022 and after.
installed libfaketime helps mitigating them.

usage :
LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1 FAKETIME="2021-01-01 00:00:00" vivado_hls

refers :
https://www.reddit.com/r/FPGA/comments/rut1dz/vitis_hls_20201_error/?utm_source=amp&utm_medium=&utm_content=tp_num_comments